### PR TITLE
Core `fnr-text` improvements

### DIFF
--- a/packages/fnr-text/src/lib/CaseHandler.ts
+++ b/packages/fnr-text/src/lib/CaseHandler.ts
@@ -1,0 +1,8 @@
+export type CaseHandler = (match: string, replaced: string) => string;
+
+export const maintainCase: CaseHandler = (match, replaced) => String(match).toUpperCase() === match ? String(replaced).toUpperCase()
+    //TODO: remove need to pass in uppercase regex
+    : match[0].toUpperCase() ? `${replaced[0].toUpperCase()}${replaced.slice(1)}`
+        : replaced;
+
+export const replaceCase: CaseHandler = (_, r) => r; 

--- a/packages/fnr-text/src/lib/CaseHandler.ts
+++ b/packages/fnr-text/src/lib/CaseHandler.ts
@@ -1,8 +1,23 @@
-export type CaseHandler = (match: string, replaced: string) => string;
+type StringIndex = number
+type SearchIndex = number
 
-export const maintainCase: CaseHandler = (match, replaced) => String(match).toUpperCase() === match ? String(replaced).toUpperCase()
-    //TODO: remove need to pass in uppercase regex
-    : match[0].toUpperCase() ? `${replaced[0].toUpperCase()}${replaced.slice(1)}`
-        : replaced;
+export type SearchMatch = 
+    { index: SearchIndex
+    , match: string
+    , groups: string[]
+    , position: StringIndex
+    , source : string
+    , namedGroups? : object
+    }
 
-export const replaceCase: CaseHandler = (_, r) => r; 
+export type CaseHandler<A> = (match : SearchMatch) => A;
+
+export const pure : <A>(a : A) => CaseHandler<A> = (s) => () => s  
+
+export const andThen = <A,B>(a : CaseHandler<A>, f : (a : A) => CaseHandler<B>) => (m : SearchMatch) => 
+    f(a(m))(m)
+
+export const maintainCase = (replaced : string) : CaseHandler<string> => ({match}) => 
+  String(match).toUpperCase() === match ? String(replaced).toUpperCase()
+  : match[0].toUpperCase() ? `${replaced[0].toUpperCase()}${replaced.slice(1)}`
+  : replaced;  

--- a/packages/fnr-text/src/lib/CaseHandler.ts
+++ b/packages/fnr-text/src/lib/CaseHandler.ts
@@ -1,6 +1,10 @@
 type StringIndex = number
 type SearchIndex = number
 
+/**
+ * CHRIS:
+ *  What is the groups property? I can get my mind around the other properties
+ */
 export type SearchMatch = 
     { index: SearchIndex
     , match: string

--- a/packages/fnr-text/src/lib/Parser.ts
+++ b/packages/fnr-text/src/lib/Parser.ts
@@ -1,0 +1,11 @@
+export type Parser<A,B> = (s : A) => B | null 
+
+export const andThen : <A,B,C>(p : Parser<A,B>, q: Parser<B,C>) => Parser<A,C> = (p, q) => (a) => { 
+  const b = p(a)
+  return b === null ? null : q(b)  
+}
+
+export const withDefault : <A,B>(p : Parser<A,B>, f : (x: A) => B) => (a :A) => B = (p,f) => (a) => {
+  const b = p(a)
+  return b === null ? f(a) : b 
+}

--- a/packages/fnr-text/src/lib/Parser.ts
+++ b/packages/fnr-text/src/lib/Parser.ts
@@ -1,5 +1,13 @@
 export type Parser<A,B> = (s : A) => B | null 
 
+/**
+ * CHRIS:
+ *  These two functions are harder for me to understand.
+ *  A good thing is the naming of the functions are good to help me understand
+ *
+ *  Could renaming the single letter variables p,q,a,b be helpful?
+ *  I think f could remain since f for func is pretty universal.
+ */
 export const andThen : <A,B,C>(p : Parser<A,B>, q: Parser<B,C>) => Parser<A,C> = (p, q) => (a) => { 
   const b = p(a)
   return b === null ? null : q(b)  

--- a/packages/fnr-text/src/lib/ResultsBuilder.ts
+++ b/packages/fnr-text/src/lib/ResultsBuilder.ts
@@ -1,12 +1,11 @@
 import { SearchResult } from './index.d';
 
-type ResultsBuilder = (results: SearchResult[], searchIndex : number, replaceIndex : number) => string;
+type ResultsBuilder = (results: SearchResult[], searchIndex : number ) => string;
 
 export const onlyReplace = (s: string): ResultsBuilder => () => s;
 
-export const replaceAndResult = (s: string, r: SearchResult): ResultsBuilder => (results: SearchResult[], searchIndex, replaceIndex) => {
+export const replaceAndResult = (s: string, r: SearchResult): ResultsBuilder => (results: SearchResult[], searchIndex) => {
     searchIndex++;
-    replaceIndex++;
     results.push(r);
     return s;
 };

--- a/packages/fnr-text/src/lib/ResultsBuilder.ts
+++ b/packages/fnr-text/src/lib/ResultsBuilder.ts
@@ -1,5 +1,6 @@
 import { SearchResult } from './index.d';
 
+//TODO: merge this with the CaseHandler type
 type ResultsBuilder = (results: SearchResult[], searchIndex : number ) => string;
 
 export const onlyReplace = (s: string): ResultsBuilder => () => s;

--- a/packages/fnr-text/src/lib/ResultsBuilder.ts
+++ b/packages/fnr-text/src/lib/ResultsBuilder.ts
@@ -5,6 +5,12 @@ type SearchIndex = number
 
 type ResultsBuilder<A> = (results: SearchResult[], searchIndex : SearchIndex) => A;
 
+/** 
+ * CHRIS:
+ *   In general, I see you using pure, andThen, andNext.
+ *   Out of curiosity, what is the reason? What are they for?
+ *   I'm new to type practices and such, or maybe its a FP thing
+ */
 export const pure = <A>(a : A) : ResultsBuilder<A> => () => a
 
 export const andThen = <A,B>(a : ResultsBuilder<A>, f : (a : A) => ResultsBuilder<B>) : ResultsBuilder<B> => (r, i) =>
@@ -21,6 +27,10 @@ export const incrementSearchIndex : ResultsBuilder<null> = (_,i) => {i++; return
 
 export const addSearchResult = (newResult : SearchResult) : ResultsBuilder<null> => (r,_) => {r.push(newResult); return null}
 
+/**
+ * CHRIS:
+ *   Being unfamiliar with these functions, how should I read this?
+ */
 export const replaceAndResult = (s : string, r : SearchResult) : ResultsBuilder<string> => 
   andNext(andNext(incrementSearchIndex, addSearchResult(r)),  pure(s))  
 

--- a/packages/fnr-text/src/lib/ResultsBuilder.ts
+++ b/packages/fnr-text/src/lib/ResultsBuilder.ts
@@ -1,0 +1,12 @@
+import { SearchResult } from './index.d';
+
+type ResultsBuilder = (results: SearchResult[], searchIndex : number, replaceIndex : number) => string;
+
+export const onlyReplace = (s: string): ResultsBuilder => () => s;
+
+export const replaceAndResult = (s: string, r: SearchResult): ResultsBuilder => (results: SearchResult[], searchIndex, replaceIndex) => {
+    searchIndex++;
+    replaceIndex++;
+    results.push(r);
+    return s;
+};

--- a/packages/fnr-text/src/lib/SourceAndFlags.ts
+++ b/packages/fnr-text/src/lib/SourceAndFlags.ts
@@ -54,18 +54,15 @@ This represents the combination of which RegExp builder to use and the match
 export type RegexerConfig = 
     { regexBuilder : Regexer
     , wordLike : RegexString
-    , uppercaseLetter : RegExp
     }
 
 export const regexBuilderAndConfigFromFunction : (r : Regexer) => RegexerConfig = r => 
   ({ regexBuilder: r
   , wordLike: `p{Letter}\\p{Number}` 
-  , uppercaseLetter: r(`\\p{Uppercase_Letter}`) 
   })
 
 
 export const defaultRegexAndConfig : RegexerConfig = 
   ({ regexBuilder: emptyRegexer 
   , wordLike : `\\w\\d`
-  , uppercaseLetter: emptyRegexer(`[A-Z]`)
   })

--- a/packages/fnr-text/src/lib/SourceAndFlags.ts
+++ b/packages/fnr-text/src/lib/SourceAndFlags.ts
@@ -1,10 +1,16 @@
 import * as P from './Parser'
 
+//TODO: rename this type type RegExpBuilder
 export type Regexer = (source: string, flags? : string) => RegExp
 export type RegexFlags = Array<string>;
 
+/**
+This represents something that builds a RegExp from a source (as in `/<source>/`) and regular
+expression flags 
+*/
 export type SourceAndFlags = (regexer : Regexer, defFlags : RegexFlags) => RegExp 
 
+//TODO: refactor flags to its own module
 export const global : RegexFlags = ['g'] 
 
 export const caseInsensitive : RegexFlags = ['i'] 
@@ -37,3 +43,27 @@ export const  regexFromString : P.Parser<string, SourceAndFlags> = P.andThen
     )
 
 export const  regexStringToRegexer : (s : string) => SourceAndFlags = P.withDefault(regexFromString, fromString) 
+
+type RegexString = string
+
+/**
+This represents something that builds a 
+*/
+export type RegexerConfig = 
+    { regexBuilder : Regexer
+    , wordLike : RegexString
+    , uppercaseLetter : RegexString
+    }
+
+export const regexBuilderAndConfigFromFunction : (r : Regexer) => RegexerConfig = r => 
+  ({ regexBuilder: r
+  , wordLike: `p{Letter}\\p{Number}` 
+  , uppercaseLetter: `\\p{Uppercase_Letter}` 
+  })
+
+
+export const defaultRegexAndConfig : RegexerConfig = 
+  ({ regexBuilder: (source: string, flags = '') => new RegExp(source, flags)
+  , wordLike : `\\w\\d`
+  , uppercaseLetter: `[A-Z]`
+  })

--- a/packages/fnr-text/src/lib/SourceAndFlags.ts
+++ b/packages/fnr-text/src/lib/SourceAndFlags.ts
@@ -5,6 +5,10 @@ export type RegexFlags = Array<string>;
 
 export type SourceAndFlags = (regexer : Regexer, defFlags : RegexFlags) => RegExp 
 
+export const global : RegexFlags = ['g'] 
+
+export const caseInsensitive : RegexFlags = ['i'] 
+
 export const  mergeFlags = (a: RegexFlags, b : RegexFlags) : RegexFlags => [...new Set([...a, ...b])]
 
 export const  onlySource = (source : string) : SourceAndFlags => (regexer, defFlags) => regexer(source, defFlags.join(''))

--- a/packages/fnr-text/src/lib/SourceAndFlags.ts
+++ b/packages/fnr-text/src/lib/SourceAndFlags.ts
@@ -35,8 +35,16 @@ export const  addFlags = (runRegexer : SourceAndFlags, flags : RegexFlags) : Sou
   /** regex gotten from findr's target input */
 export const  fromRegex = (r : RegExp) : SourceAndFlags => onlySource(r.source)
 
+/**
+ * CHRIS:
+ *   Can we abstract this regex into a CONST and name it so we know what it's doing?
+ */
 export const  fromString = (s: string) : SourceAndFlags => onlySource(s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
 
+/**
+ * CHRIS:
+ *   Same here about abstracting the regex. Also this is hard for me to udnerstand
+ */
 export const  regexFromString : P.Parser<string, SourceAndFlags> = P.andThen 
     (s => s.match(/\/(.+)\/(?=(\w*$))/)
     , results => results?.length === 3 

--- a/packages/fnr-text/src/lib/SourceAndFlags.ts
+++ b/packages/fnr-text/src/lib/SourceAndFlags.ts
@@ -1,0 +1,35 @@
+import * as P from './Parser'
+
+export type Regexer = (source: string, flags? : string) => RegExp
+export type RegexFlags = Array<string>;
+
+export type SourceAndFlags = (regexer : Regexer, defFlags : RegexFlags) => RegExp 
+
+export const  mergeFlags = (a: RegexFlags, b : RegexFlags) : RegexFlags => [...new Set([...a, ...b])]
+
+export const  onlySource = (source : string) : SourceAndFlags => (regexer, defFlags) => regexer(source, defFlags.join(''))
+
+export const  addFlags = (runRegexer : SourceAndFlags, flags : RegexFlags) : SourceAndFlags => (regexer, defFlags) =>  
+    runRegexer(regexer, mergeFlags(flags, defFlags))
+  
+  //TODO: is this necessary? isRegex is typed to be a boolean. If users are
+  //using TS this check is unecessary. If the users are using JS to consume this
+  //library maybe we should think about a more generic way to enforce types at 
+  //runtime?
+  //TODO: remove isRegex from interface of findr
+  /** is findr being used in regex mode */
+  //TODO: isRegex : Bool -> (TargetString -> { source : string, flags: Flags})
+  //rewrite isRegex to use 2 available function types
+  /** regex gotten from findr's target input */
+export const  fromRegex = (r : RegExp) : SourceAndFlags => onlySource(r.source)
+
+export const  fromString = (s: string) : SourceAndFlags => onlySource(s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+
+export const  regexFromString : P.Parser<string, SourceAndFlags> = P.andThen 
+    (s => s.match(/\/(.+)\/(?=(\w*$))/)
+    , results => results?.length === 3 
+        ? addFlags(onlySource(results[1]), [...results[2]])  
+        : null 
+    )
+
+export const  regexStringToRegexer : (s : string) => SourceAndFlags = P.withDefault(regexFromString, fromString) 

--- a/packages/fnr-text/src/lib/SourceAndFlags.ts
+++ b/packages/fnr-text/src/lib/SourceAndFlags.ts
@@ -15,6 +15,8 @@ export const global : RegexFlags = ['g']
 
 export const caseInsensitive : RegexFlags = ['i'] 
 
+export const emptyRegexer = (source: string, flags = '') => new RegExp(source, flags)
+
 export const  mergeFlags = (a: RegexFlags, b : RegexFlags) : RegexFlags => [...new Set([...a, ...b])]
 
 export const  onlySource = (source : string) : SourceAndFlags => (regexer, defFlags) => regexer(source, defFlags.join(''))
@@ -47,23 +49,23 @@ export const  regexStringToRegexer : (s : string) => SourceAndFlags = P.withDefa
 type RegexString = string
 
 /**
-This represents something that builds a 
+This represents the combination of which RegExp builder to use and the match 
 */
 export type RegexerConfig = 
     { regexBuilder : Regexer
     , wordLike : RegexString
-    , uppercaseLetter : RegexString
+    , uppercaseLetter : RegExp
     }
 
 export const regexBuilderAndConfigFromFunction : (r : Regexer) => RegexerConfig = r => 
   ({ regexBuilder: r
   , wordLike: `p{Letter}\\p{Number}` 
-  , uppercaseLetter: `\\p{Uppercase_Letter}` 
+  , uppercaseLetter: r(`\\p{Uppercase_Letter}`) 
   })
 
 
 export const defaultRegexAndConfig : RegexerConfig = 
-  ({ regexBuilder: (source: string, flags = '') => new RegExp(source, flags)
+  ({ regexBuilder: emptyRegexer 
   , wordLike : `\\w\\d`
-  , uppercaseLetter: `[A-Z]`
+  , uppercaseLetter: emptyRegexer(`[A-Z]`)
   })

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -18,7 +18,7 @@ export type ResultKey = string | number;
 
 export type Metadata = { [key: string]: unknown };
 
-export type replacementCallback = (params: {
+export type ReplacementCallback = (params: {
   index: number;
   match: string;
   groups: Array<string>;
@@ -32,7 +32,7 @@ type resultsAll = 'all';
 export interface FindrParams {
   source: string;
   target: string | RegExp;
-  replacement?: string | replacementCallback;
+  replacement?: string | ReplacementCallback;
   contextLength?: number;
   replacementKeys?: Array<ResultKey> | resultsAll;
   metadata?: Metadata;

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -1,11 +1,13 @@
 import XRegeExp from 'xregexp/types';
 
-export declare const findr: (params: FindrParams) => FindrReturn;
+export declare const findr: (params: SearchAndReplace) => ReplacedAndResults;
+
+export type Filter = (match: string) => string;
 
 export interface FindrConfig {
   ctxLen?: number;
-  filterCtxMatch?: (match: string) => string;
-  filterCtxReplacement?: (replacement: string) => string;
+  filterCtxMatch?: Filter;
+  filterCtxReplacement?: Filter;
   buildResultKey?: (index: number) => ResultKey;
   xregexp?: typeof XRegeExp;
   isRegex?: boolean;
@@ -16,6 +18,17 @@ export interface FindrConfig {
 
 export type ResultKey = string | number;
 
+//TODO: make this well typed
+// 
+// {
+//  source: source,
+//  match: match,
+//  searchIndex,
+//  position: pos,
+//  groups: args,
+//  namedGroups,
+//  ...metadata,
+// }
 export type Metadata = { [key: string]: unknown };
 
 export type ReplacementCallback = (params: {
@@ -29,7 +42,7 @@ export type ReplacementCallback = (params: {
 
 type ResultsAll = 'all';
 
-export interface FindrParams {
+export interface SearchAndReplace {
   source: string;
   target: string | RegExp;
   replacement?: string | ReplacementCallback;
@@ -44,7 +57,7 @@ export interface Context {
   after: string;
 }
 
-export interface FindrResult {
+export interface SearchResult {
   match: string;
   replacement: string;
   context: Context;
@@ -53,11 +66,11 @@ export interface FindrResult {
   metadata: Metadata;
 }
 
-export type FindrReplaced = string;
+export type ReplacedText = string;
 
-export interface FindrReturn {
-  replaced: FindrReplaced;
-  results: FindrResult[];
+export interface ReplacedAndResults {
+  replaced: ReplacedText;
+  results: SearchResult[];
 }
 
 export default findr;

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -4,6 +4,8 @@ export declare const findr: (params: SearchAndReplace) => ReplacedAndResults;
 
 export type Filter = (match: string) => string;
 
+//TODO: is this really config? Config generally implies a consumer's app will set these values ONCE and use everywhere.
+//for discoverability maybe we could rename this to SearchSettings?
 export interface FindrConfig {
   ctxLen?: number;
   filterCtxMatch?: Filter;
@@ -16,7 +18,6 @@ export interface FindrConfig {
   isCasePreserved?: boolean;
 }
 
-export type ResultKey = string | number;
 
 //TODO: make this well typed
 // 
@@ -40,7 +41,8 @@ export type ReplacementCallback = (params: {
   namedGroups: { [key: string]: unknown };
 }) => string;
 
-type ResultsAll = 'all';
+export type ResultsAll = 'all';
+export type ResultKey = string | number;
 
 export interface SearchAndReplace {
   source: string;

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -16,7 +16,7 @@ export interface FindrConfig {
 
 export type ResultKey = string | number;
 
-export type metadata = { [key: string]: unknown };
+export type Metadata = { [key: string]: unknown };
 
 export type replacementCallback = (params: {
   index: number;
@@ -35,7 +35,7 @@ export interface FindrParams {
   replacement?: string | replacementCallback;
   contextLength?: number;
   replacementKeys?: Array<ResultKey> | resultsAll;
-  metadata?: metadata;
+  metadata?: Metadata;
   config?: FindrConfig;
 }
 
@@ -50,7 +50,7 @@ export interface FindrResult {
   context: Context;
   extContext: Context;
   resultKey: ResultKey;
-  metadata: metadata;
+  metadata: Metadata;
 }
 
 export type FindrReplaced = string;

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -65,7 +65,7 @@ export interface SearchAndReplace {
 }
 
 //TODO: rename the Context to something that is more meaningful. Namely, what is this the "context" of?
-export interface Context {
+export interface SurroundingContext {
   before: string;
   after: string;
 }
@@ -73,8 +73,8 @@ export interface Context {
 export interface SearchResult {
   match: string;
   replacement: string;
-  context: Context;
-  extContext: Context;
+  context: SurroundingContext;
+  extContext: SurroundingContext;
   resultKey: ResultKey;
   metadata: Metadata;
 }

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -6,7 +6,7 @@ export interface FindrConfig {
   ctxLen?: number;
   filterCtxMatch?: (match: string) => string;
   filterCtxReplacement?: (replacement: string) => string;
-  buildResultKey?: (index: number) => resultKey;
+  buildResultKey?: (index: number) => ResultKey;
   xregexp?: typeof XRegeExp;
   isRegex?: boolean;
   isCaseMatched?: boolean;
@@ -14,8 +14,10 @@ export interface FindrConfig {
   isCasePreserved?: boolean;
 }
 
-export type resultKey = string | number;
+export type ResultKey = string | number;
+
 export type metadata = { [key: string]: unknown };
+
 export type replacementCallback = (params: {
   index: number;
   match: string;
@@ -26,12 +28,13 @@ export type replacementCallback = (params: {
 }) => string;
 
 type resultsAll = 'all';
+
 export interface FindrParams {
   source: string;
   target: string | RegExp;
   replacement?: string | replacementCallback;
   contextLength?: number;
-  replacementKeys?: Array<resultKey> | resultsAll;
+  replacementKeys?: Array<ResultKey> | resultsAll;
   metadata?: metadata;
   config?: FindrConfig;
 }
@@ -46,7 +49,7 @@ export interface FindrResult {
   replacement: string;
   context: Context;
   extContext: Context;
-  resultKey: resultKey;
+  resultKey: ResultKey;
   metadata: metadata;
 }
 

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -27,14 +27,14 @@ export type ReplacementCallback = (params: {
   namedGroups: { [key: string]: unknown };
 }) => string;
 
-type resultsAll = 'all';
+type ResultsAll = 'all';
 
 export interface FindrParams {
   source: string;
   target: string | RegExp;
   replacement?: string | ReplacementCallback;
   contextLength?: number;
-  replacementKeys?: Array<ResultKey> | resultsAll;
+  replacementKeys?: Array<ResultKey> | ResultsAll;
   metadata?: Metadata;
   config?: FindrConfig;
 }

--- a/packages/fnr-text/src/lib/index.d.ts
+++ b/packages/fnr-text/src/lib/index.d.ts
@@ -6,11 +6,15 @@ export type Filter = (match: string) => string;
 
 //TODO: is this really config? Config generally implies a consumer's app will set these values ONCE and use everywhere.
 //for discoverability maybe we could rename this to SearchSettings?
+//TODO: this type has all Maybe keys. do we need them?
+//TODO: are all of these values being consumed in the core functionality?
 export interface FindrConfig {
   ctxLen?: number;
   filterCtxMatch?: Filter;
   filterCtxReplacement?: Filter;
   buildResultKey?: (index: number) => ResultKey;
+  //TODO: provide an explicitely defined type for XRegExp so users can more readly provide a value 
+  //TODO: typo, should be XRegeExp
   xregexp?: typeof XRegeExp;
   isRegex?: boolean;
   isCaseMatched?: boolean;
@@ -20,22 +24,25 @@ export interface FindrConfig {
 
 
 //TODO: make this well typed
-// 
+// A brief look at the source code reveals it's type could be:
 // {
-//  source: source,
-//  match: match,
-//  searchIndex,
-//  position: pos,
-//  groups: args,
-//  namedGroups,
+//  source: typeof source,
+//  match: typeof match,
+//  searchIndex: typeof searchIndex,
+//  position: typeof pos,
+//  groups: typeof args,
+//  namedGroups: typeof namedGroups,
 //  ...metadata,
 // }
 export type Metadata = { [key: string]: unknown };
 
+//TODO: extract the argument type (maybe create a more generic Callback type?)
+//TODO: return type has `string` blindness.
 export type ReplacementCallback = (params: {
   index: number;
   match: string;
   groups: Array<string>;
+  //TODO: use a more refined type like a Natural. Things like negative numbers should be impossible to use here.
   position: number;
   source: string;
   namedGroups: { [key: string]: unknown };
@@ -44,6 +51,9 @@ export type ReplacementCallback = (params: {
 export type ResultsAll = 'all';
 export type ResultKey = string | number;
 
+//TODO: avoid `string` type here. `string` implies ANY string. Does ANY string really work for these types?
+//TODO: often when a variable is either a `string | a` then we are actually defining a more refined type `b` with 2
+//constructors: `fromString : string -> b` and `fromA : a -> b`.
 export interface SearchAndReplace {
   source: string;
   target: string | RegExp;
@@ -54,6 +64,7 @@ export interface SearchAndReplace {
   config?: FindrConfig;
 }
 
+//TODO: rename the Context to something that is more meaningful. Namely, what is this the "context" of?
 export interface Context {
   before: string;
   after: string;

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -82,6 +82,7 @@ export function findr({
     isWordMatched: boolean;
   }) {
     const { source, flags } = regexp;
+    //TODO: you have here an EDSL for constructing regexes...why not make this its own module?
     return isWordMatched
       ? regexer(`(^|[^${wordLike}])(${source})(?=[^${wordLike}]|$)`, flags)
       : regexer(`()(${source})`, flags);
@@ -196,6 +197,7 @@ export function findr({
           /** replacement string modified to match findr's replacement config */
           const replaced = evaluateCase(match, match.replace(finalRgx, r));
 
+          //TODO: I don't this interface to buildResultKey is a good idea...just a gut feeling here.
           /** key for specific match index that needs to be replaced */
           const replacePointer: ResultKey = buildResultKey
             ? buildResultKey(replaceIndex)

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -6,26 +6,6 @@ import * as S from './SourceAndFlags'
 *  Match Word, Regex, and allowing consumers to extend it further.
 *  It formats it's response in a way that is easier to consume by a Find and Replace UI.
 */
-
-/*
-TODO: Code Readability Suggestions
-
-It could be helpful to **separate Findr and Multiline into separate
-files and then import/export them in `index.ts`**.  It’s harder exploring
-through the codebase when I’m sorting through which `index.ts` file I’m looking at.
-- It also makes the imports within the files more readable (I get confused when
-  I see imports of index files and which folder they’re being imported from.
-  Like import x from “../../.”)
-
-A lot of the code was in one bigger function. **Creating smaller functions that
-group similar operations** (creating flags, preparing initial regex, etc.)
-**could help improve readability.**
-  1. For Example…
-      1. Wrapping the functionality in `source.replace` on **line 74** in a function
-      2. Wrapping the `defaultFlags` const with other code that generates flags
-      3. etc.
-*/
-
 export default function findr({
   source,
   target,
@@ -49,11 +29,11 @@ export default function findr({
   /** default flags to be used for regex pattern */
   const defaultFlags : S.RegexFlags =  !isCaseMatched ? S.mergeFlags(S.global, S.caseInsensitive) : S.global;
 
+  //TODO: needs increased support for multiple languages
   /** regex engine (default or xregexp) */
   /** is user providing an instance of XRegExp */
   const {regexBuilder, wordLike, uppercaseLetter} = xre instanceof Function
     ? { regexBuilder: xre 
-      //TODO: needs increased support for multiple languages
       /** regex pattern for a wordlike character */
       , wordLike: `p{Letter}\\p{Number}` 
 

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -48,9 +48,8 @@ export default function findr({
 }: SearchAndReplace) {
   // START BUILDING SEARCH REGEXP
 
-  //TODO: refactor this bit so ['g'] is a constant exported from S
   /** default flags to be used for regex pattern */
-  const defaultFlags : S.RegexFlags =  !isCaseMatched ? ['g', 'i'] : ['g'];
+  const defaultFlags : S.RegexFlags =  !isCaseMatched ? S.mergeFlags(S.global, S.caseInsensitive) : S.global;
 
   /** regex engine (default or xregexp) */
   /** is user providing an instance of XRegExp */

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -53,13 +53,16 @@ export default function findr({
   let searchIndex = 0;
   let results : SearchResult[] = []
 
-  
-  const createReplacement = typeof replacement === 'function' ? replacement : () => replacement
+  const createReplacement = 
+    C.andThen
+    ( typeof replacement === 'function' ? (replacement as C.CaseHandler<string>) 
+      : C.pure(replacement)
+    , isCasePreserved ? C.maintainCase : C.pure 
+    )
 
   //TODO: it might be worth using a Reader functor here...
   const replaceFunc_ = (a : any, b : any, c : any, ...d : any[]) => replaceFunc
     ( source
-    , isCasePreserved ? C.maintainCase : C.replaceCase 
     , createReplacement
     , buildResultKey
     , replacementKeys
@@ -83,8 +86,7 @@ export default function findr({
 
 function replaceFunc
   ( source : string
-  , handleCase : C.CaseHandler
-  , createReplacement : (x : any) => string
+  , createReplacement : C.CaseHandler<string>
   //TODO: eliminate from function argument
   , buildResultKey : any
   , replacementKeys : any
@@ -113,14 +115,14 @@ function replaceFunc
   const oldArgs = args.slice(0, hasGroups ? -3 : -2)
 
   /** replacement string modified to match findr's replacement config */
-  const replacedCaseHandled = handleCase(subStringMatch, createReplacement(
+  const replacedCaseHandled = createReplacement(
     { index: searchIndex
     , match: subStringMatch
     , groups: oldArgs
     , position: pos
     , source
     , namedGroups 
-    }))
+    })
 
   const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(searchIndex)) 
 

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -71,7 +71,7 @@ export default function findr({
 
   //TODO: break the external API so this is no longer needed
   const adjoinMetadata = ({metadata, ...result} : SearchResult) => 
-    ({ metadata : {...metadata, source, ...mdata}
+    ({ metadata : {...metadata, source, match: result.match, ...mdata}
     , ...result
     })
 
@@ -141,8 +141,6 @@ function replaceFunc
         },
       resultKey: buildResultKey(searchIndex),
       metadata: {
-          //TODO: remove this since it's unecessary (and already included in the above code)
-          match: subStringMatch,
           searchIndex,
           position: pos,
           groups: oldArgs,

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -1,4 +1,4 @@
-import { SearchAndReplace, SearchResult, ResultKey } from './index.d';
+import { SearchAndReplace, SearchResult, ResultKey, Filter } from './index.d';
 import { escapeRegExp, evalRegex, isUpperCase } from './utils';
 
 type RegexFlags = Array<string>;
@@ -229,27 +229,7 @@ export function findr({
     // START BUILDING THE RESULT IF MATCH IS NOT REPLACED
 
     /** substring before matched result */
-    const ctxBefore = source.slice(pos - ctxLen, pos);
-    /** substring after matched result */
-    const ctxAfter = source.slice(
-      pos + match.length,
-      pos + match.length + ctxLen
-    );
-
-    /** all source text before matched result */
-    const extCtxBefore = source.slice(0, pos);
-    /** all source text after matched result */
-    const extCtxAfter = source.slice(pos + match.length, -1);
-
-    const ctxMatch = filterCtxMatch ? filterCtxMatch(match) : match;
-    const ctxReplacement = filterCtxReplacement
-      ? filterCtxReplacement(replaced)
-      : replaced;
-
-    /** creates a pointer to this result */
-    const searchPointer = buildResultKey
-      ? buildResultKey(searchIndex)
-      : searchIndex;
+    const { ctxMatch, ctxReplacement, ctxBefore, ctxAfter, extCtxBefore, extCtxAfter, searchPointer } = preMatchSubstring(source, pos, ctxLen, match, filterCtxMatch, filterCtxReplacement, replaced, buildResultKey, searchIndex);
 
     //TODO: add result metadata as filterCtxReplacement arg
     const result = {
@@ -268,6 +248,7 @@ export function findr({
         ...metadata,
       },
     };
+
     results.push(result);
     //TODO: is there a stateless way to do this? It's difficult to follow the denotational semantics
     //of the code given a stateful variable like this.
@@ -283,3 +264,29 @@ export function findr({
 }
 
 export default findr
+
+function preMatchSubstring(source: any, pos: any, ctxLen: number, match: string, filterCtxMatch: Filter, filterCtxReplacement: Filter, replaced: string, buildResultKey: ((index: number) => ResultKey) | undefined, searchIndex: number) {
+    const ctxBefore = source.slice(pos - ctxLen, pos);
+    /** substring after matched result */
+    const ctxAfter = source.slice(
+        pos + match.length,
+        pos + match.length + ctxLen
+    );
+
+    /** all source text before matched result */
+    const extCtxBefore = source.slice(0, pos);
+    /** all source text after matched result */
+    const extCtxAfter = source.slice(pos + match.length, -1);
+
+    const ctxMatch = filterCtxMatch ? filterCtxMatch(match) : match;
+    const ctxReplacement = filterCtxReplacement
+        ? filterCtxReplacement(replaced)
+        : replaced;
+
+    /** creates a pointer to this result */
+    const searchPointer = buildResultKey
+        ? buildResultKey(searchIndex)
+        : searchIndex;
+    return { ctxMatch, ctxReplacement, ctxBefore, ctxAfter, extCtxBefore, extCtxAfter, searchPointer };
+}
+

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -148,11 +148,13 @@ function replaceFunc
   /** if the last argument of string.replace callback is an object it means the regexp contains groups */
   //TODO: why is the `match` the 3rd subgroup?
   const replacedText = match.replace
-          (finalRgx, 
-            typeof replacement === 'function' 
-              ? () => replacement({ index: replaceIndex, match, groups: args, position: pos, source, namedGroups })
-              : () => replacement
-          )
+    (finalRgx, 
+      //TODO: invert the dependencies here
+      typeof replacement === 'function' 
+        ? () => replacement({ index: replaceIndex, match, groups: args, position: pos, source, namedGroups })
+        : () => replacement
+    )
+
   /** replacement string modified to match findr's replacement config */
   const replacedCaseHandled = 
     !isCasePreserved ? replacedText
@@ -167,12 +169,11 @@ function replaceFunc
   if (replacementKeys === 'all' || replacementKeys.includes(buildResultKey(replaceIndex) as string) ) 
   { /** if a replacementKey matches current result this result won't be included in the list of results */
     //TODO: why are we concatenating the first subgroup with the replaced text? 
-      return auxMatch + replacedCaseHandled;
+    return auxMatch + replacedCaseHandled;
   }
 
-
   //TODO: add result metadata as filterCtxReplacement arg
-  const result = {
+  results.push({
       match: filterCtxMatch ? filterCtxMatch(match) : match,
       replacement: filterCtxReplacement ? filterCtxReplacement(replacedCaseHandled) : replacedCaseHandled,
       context: 
@@ -195,9 +196,7 @@ function replaceFunc
           namedGroups,
           ...metadata,
       },
-  };
-
-  results.push(result);
+  })
 
   //TODO: is there a stateless way to do this? It's difficult to follow the denotational semantics
   //of the code given a stateful variable like this.
@@ -205,5 +204,4 @@ function replaceFunc
   replaceIndex++;
 
   return tmpMatch;
-}} 
-
+}}  

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -19,6 +19,7 @@ export function findr({
     filterCtxReplacement = (replacement: string) => replacement,
     buildResultKey,
     ctxLen = 0,
+    //TODO: rename xre - it's difficult to follow
     xregexp: xre,
     isRegex = false,
     isCaseMatched = true,
@@ -202,10 +203,11 @@ export function findr({
           const replacePointer: ResultKey = buildResultKey
             ? buildResultKey(replaceIndex)
             : replaceIndex;
+
           replaceIndex++;
 
-          // REPLACE IF replacePointer IS INCLUDED IN replacementKeys given by user
 
+          // REPLACE IF replacePointer IS INCLUDED IN replacementKeys given by user
           if (
             replacementKeys === 'all' ||
             replacementKeys.includes(replacePointer as string)

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -36,7 +36,7 @@ export function findr({
   //library maybe we should think about a more generic way to enforce types at 
   //runtime?
   /** is findr being used in regex mode */
-  const isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
+  isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
 
   //TODO: I would recommend against using console.warn as an error handling mechanism
   //this cloggs up the users console and doesn't provide the user an ability to handle
@@ -47,11 +47,14 @@ export function findr({
   if (!isRegex && target instanceof RegExp)
     console.warn('isRegex is set to false but target of type RegExp given.');
 
+
+  //TODO: this could be defunctionalized...
+  //TODO: code-smell. Typically when you have an boolean and you're doing if-then statements based
+  //on that boolean then there's a logic inversion that can be performed to simplify the code (defunctionalization).
+  /** regex engine (default or xregexp) */
   /** is user providing an instance of XRegExp */
   const isXre = xre instanceof Function;
 
-  //TODO: this could be defunctionalized...
-  /** regex engine (default or xregexp) */
   const regexer = isXre
     ? xre
     : function (source: string, flags = '') {
@@ -111,7 +114,8 @@ export function findr({
 
   //TODO: place: initial array ---> array construction logic ---> final array with a fold/reduce pattern
   const results: SearchResult[] = [];
-  //TODO: there is a lot going on within this single variable assignment. I suggest refactoring this logic
+  //TODO: there is a lot going on within this single variable assignment. I suggest refactoring this logic to
+  //make the `... ? ... : ...` syntax more clear.
   //TODO: rework the types involved so that this empty string check isn't required
   const replaced =
     target !== ''

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -70,32 +70,28 @@ export default function findr({
     console.warn('isRegex is set to false but target of type RegExp given.');
 
 
-  //TODO: this could be defunctionalized...
-  //TODO: code-smell. Typically when you have an boolean and you're doing if-then statements based
-  //on that boolean then there's a logic inversion that can be performed to simplify the code (defunctionalization).
   /** regex engine (default or xregexp) */
   /** is user providing an instance of XRegExp */
-  const isXre = xre instanceof Function;
+  const {regexer, wordLike, uppercaseLetter} = xre instanceof Function
+    ? { regexer: xre 
+      //TODO: needs increased support for multiple languages
+      /** regex pattern for a wordlike character */
+      , wordLike: `p{Letter}\\p{Number}` 
 
-  const regexer : Regexer = isXre
-    ? xre
-    : function (source: string, flags = '') {
-        return new RegExp(source, flags);
-      };
+      /** regex pattern for uppercase character */
+      , uppercaseLetter: `\\p{Uppercase_Letter}` 
+      }
 
-  //TODO: I'm seeing a code-smell here. Performing if-then statements to variable assignment
-  //is running an evaluator to early. 
-  //TODO: needs increased support for multiple languages
-  /** regex pattern for a wordlike character */
-  const wordLike = isXre ? `p{Letter}\\p{Number}` : `\\w\\d`;
+    : { regexer: (source: string, flags = '') => new RegExp(source, flags)
+      /** regex pattern for a wordlike character */
+      , wordLike : `\\w\\d`
 
-  /** regex pattern for uppercase character */
-  const uppercaseLetter = isXre ? `\\p{Uppercase_Letter}` : `[A-Z]`;
+      /** regex pattern for uppercase character */
+      , uppercaseLetter: `[A-Z]`
+      }
 
   /** regex gotten from findr's target input */
-  const rgxData = isRegex
-    ? evalRegex(target)
-    : { source: escapeRegExp(target), flags: null };
+  const rgxData = isRegex ? evalRegex(target) : { source: escapeRegExp(target), flags: null };
 
   //TODO: this could be a small EDSL under with Semigroup, Monoid, etc. instances
   /** merged default flags with inputted flags */

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -58,7 +58,6 @@ export default function findr({
     ( source
     , uppercaseLetter
     , isCasePreserved
-    , targetRegex
     , replacement
     , replaceIndex
     , buildResultKey
@@ -80,7 +79,6 @@ function replaceFunc
   ( source : string
   , uppercaseLetter : any
   , isCasePreserved : any
-  , targetRegex : any
   , replacement : any
   //TODO: eliminate from function argument
   , replaceIndex : any
@@ -113,13 +111,18 @@ function replaceFunc
 
   /** if the last argument of string.replace callback is an object it means the regexp contains groups */
   //TODO: why is the `match` the 3rd subgroup?
-  const replacedText = match.replace
-    (targetRegex, 
-      //TODO: invert the dependencies here
-      typeof replacement === 'function' 
-        ? () => replacement({ index: replaceIndex, match, groups: oldArgs, position: pos, source, namedGroups })
-        : () => replacement
-    )
+  const replacedText = 
+    typeof replacement === 'function' 
+        ? replacement({ index: replaceIndex, match, groups: oldArgs, position: pos, source, namedGroups })
+        : replacement
+
+    //match.replace
+    //(targetRegex, 
+    //  //TODO: invert the dependencies here
+    //  typeof replacement === 'function' 
+    //    ? () => replacement({ index: replaceIndex, match, groups: oldArgs, position: pos, source, namedGroups })
+    //    : () => replacement
+    //)
 
   /** replacement string modified to match findr's replacement config */
   const replacedCaseHandled = 

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -145,13 +145,18 @@ function replaceFunc
   //TODO: rename this to something more understandable
   const pos = args.at(hasGroups ? -3 : -2) + auxMatch.length;
 
+  
+  //TODO: remove the need for oldArgs (this will break the legacy API)
+  //in order to maintain the legacy behavior of args we need to modify the args array
+  const oldArgs = args.slice(0, hasGroups ? -3 : -2)
+
   /** if the last argument of string.replace callback is an object it means the regexp contains groups */
   //TODO: why is the `match` the 3rd subgroup?
   const replacedText = match.replace
     (finalRgx, 
       //TODO: invert the dependencies here
       typeof replacement === 'function' 
-        ? () => replacement({ index: replaceIndex, match, groups: args, position: pos, source, namedGroups })
+        ? () => replacement({ index: replaceIndex, match, groups: oldArgs, position: pos, source, namedGroups })
         : () => replacement
     )
 
@@ -192,7 +197,7 @@ function replaceFunc
           match: match,
           searchIndex,
           position: pos,
-          groups: args,
+          groups: oldArgs,
           namedGroups,
           ...metadata,
       },

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -1,3 +1,4 @@
+import * as C from './CaseHandler';
 import { SearchAndReplace, SearchResult } from './index.d';
 import { onlyReplace, replaceAndResult } from './ResultsBuilder';
 import * as S from './SourceAndFlags'
@@ -55,7 +56,7 @@ export default function findr({
   //TODO: it might be worth using a Reader functor here...
   const replaceFunc_ = (a : any, b : any, c : any, ...d : any[]) => replaceFunc
     ( source
-    , isCasePreserved
+    , isCasePreserved ? C.maintainCase : C.replaceCase 
     , replacement
     , buildResultKey
     , replacementKeys
@@ -76,15 +77,9 @@ export default function findr({
   return { results: results.map(adjoinMetadata), replaced };
 }
 
-const maintainCase = (match : string, replaced : string) =>
-  String(match).toUpperCase() === match ? String(replaced).toUpperCase() 
-  //TODO: remove need to pass in uppercase regex
-  : match[0].toUpperCase() ? `${replaced[0].toUpperCase()}${replaced.slice(1)}`
-  : replaced
-
 function replaceFunc
   ( source : string
-  , isCasePreserved : any
+  , handleCase : C.CaseHandler
   , replacement : any
   //TODO: eliminate from function argument
   , buildResultKey : any
@@ -121,9 +116,9 @@ function replaceFunc
     : replacement
 
   /** replacement string modified to match findr's replacement config */
-  const replacedCaseHandled =  !isCasePreserved ? replacedText : maintainCase(subStringMatch, replacedText)
+  const replacedCaseHandled = handleCase(subStringMatch, replacedText)
 
-  const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(searchIndex) as string) 
+  const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(searchIndex)) 
 
   //TODO: I don't this interface to buildResultKey is a good idea...just a gut feeling here.
   //TODO: unify the return results

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -211,8 +211,14 @@ function replaceFunc
   const result = {
       match: filterCtxMatch ? filterCtxMatch(match) : match,
       replacement: filterCtxReplacement ? filterCtxReplacement(replaced) : replaced,
-      context: { before: source.slice(pos - ctxLen, pos), after: source.slice(pos + match.length, pos + match.length + ctxLen) },
-      extContext: { before: source.slice(0, pos), after: source.slice(pos + match.length, -1) },
+      context: 
+        { before: source.slice(pos - ctxLen, pos),
+          after: source.slice(pos + match.length, pos + match.length + ctxLen) 
+        },
+      extContext: 
+        { before: source.slice(0, pos),
+          after: source.slice(pos + match.length, -1) 
+        },
       resultKey: buildResultKey(searchIndex),
       metadata: {
           source: source,
@@ -234,17 +240,25 @@ function replaceFunc
   return tmpMatch;
 }}
 
-function handleRegexGroups(args: any[]) : { match: string; pos: any; source: any; namedGroups: any; auxMatch: any; tmpMatch: any; } {
-  const containsGroup = typeof args[args.length - 1] === 'object';
+function handleRegexGroups(args: any[]) : { match: any; pos: any; source: any; namedGroups: any; auxMatch: any; tmpMatch: any; } {
+  const hasGroups = typeof args.at(-1) === 'object'
 
-  /** get the groups if they exist and remove them from args */
-  const namedGroups = containsGroup ? args.pop() : undefined;
-  const source = args.pop();
-  const tmpPos = args.pop();
-  const tmpMatch = args.shift();
-  const auxMatch = args.shift();
+  const argsOffset = hasGroups ? 0 : 1;
+
+  const namedGroups = hasGroups ? args.at(-1) : undefined;
+
+  //TODO: this is unecessary...since we already have access to it from the main function
+  const source = args.at(-2+argsOffset);
+
+  //TODO: rename to offset
+  const tmpPos = args.at(-3+argsOffset);
+
+  //TODO: this is equivalent to match
+  const tmpMatch = args.at(0);
+  const auxMatch = args.at(1);
+  const match = args.at(2);
+
   const pos = tmpPos + auxMatch.length;
-  const match = args.shift();
 
   return { match, pos, source, namedGroups, auxMatch, tmpMatch };
 }     

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -125,26 +125,6 @@ function replacementCallbackFunc
   
 function replacementString(s : string) : (() => string) {return () => s}
 
-function preMatchSubstring(source: any, pos: any, ctxLen: number, match: string ) {
-    const ctxBefore = source.slice(pos - ctxLen, pos);
-
-    /** substring after matched result */
-    const ctxAfter = source.slice(
-        pos + match.length,
-        pos + match.length + ctxLen
-    );
-
-    /** all source text before matched result */
-    const extCtxBefore = source.slice(0, pos);
-
-    /** all source text after matched result */
-    const extCtxAfter = source.slice(pos + match.length, -1);
-
-    return { ctxBefore, ctxAfter, extCtxBefore, extCtxAfter  };
-}
-
-
-  
 function isUpperCase(input: string) {
   //TODO: this is equivalent to ()
   return input.toUpperCase() === input && input.toLowerCase() !== input;
@@ -212,24 +192,6 @@ function replaceFunc
         )
     )
 
-  //TODO: code-smell: this variable is only used once and its callsite is assignment to an object key.
-  //in essense there are 2 names assigned to something that only has one meaning.
-  //I would recommend removing this variable assignment. This applies to the following name-bindings:
-  //  - ctxBefore
-  //  - ctxAfter
-  //  - ctxMatch
-  //  - ctxReplacement
-  //  - searchPointer
-  //  - result (this is only being used as the argument to `results.push`)
-  // START BUILDING THE RESULT IF MATCH IS NOT REPLACED
-  /** substring before matched result */
-  const { ctxBefore, ctxAfter, extCtxBefore, extCtxAfter } = preMatchSubstring
-    ( source
-    , pos
-    , ctxLen
-    , match
-    )
-
   //TODO: I don't this interface to buildResultKey is a good idea...just a gut feeling here.
   /** key for specific match index that needs to be replaced */
   const replacePointer: ResultKey = buildResultKey
@@ -249,8 +211,8 @@ function replaceFunc
   const result = {
       match: filterCtxMatch ? filterCtxMatch(match) : match,
       replacement: filterCtxReplacement ? filterCtxReplacement(replaced) : replaced,
-      context: { before: ctxBefore, after: ctxAfter },
-      extContext: { before: extCtxBefore, after: extCtxAfter },
+      context: { before: source.slice(pos - ctxLen, pos), after: source.slice(pos + match.length, pos + match.length + ctxLen) },
+      extContext: { before: source.slice(0, pos), after: source.slice(pos + match.length, -1) },
       resultKey: buildResultKey(searchIndex),
       metadata: {
           source: source,

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -69,8 +69,9 @@ export default function findr({
   //TODO: rework the types involved so that this empty string check isn't required
   const replaced = target !== '' ? source.replace(wholeWordRegex, replaceFunc_) : source;
 
+  //TODO: break the external API so this is no longer needed
   const adjoinMetadata = ({metadata, ...result} : SearchResult) => 
-    ({ metadata : {...metadata, ...mdata}
+    ({ metadata : {...metadata, source, ...mdata}
     , ...result
     })
 
@@ -140,8 +141,6 @@ function replaceFunc
         },
       resultKey: buildResultKey(searchIndex),
       metadata: {
-          //TODO: remove this since it's unecessary and bloating the return value
-          source: source,
           //TODO: remove this since it's unecessary (and already included in the above code)
           match: subStringMatch,
           searchIndex,

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -31,8 +31,15 @@ export function findr({
   /** default flags to be used for regex pattern */
   const defaultFlags : RegexFlags =  !isCaseMatched ? ['g', 'i'] : ['g'];
 
-  const _isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
+  //TODO: is this necessary? isRegex is typed to be a boolean. If users are
+  //using TS this check is unecessary. If the users are using JS to consume this
+  //library maybe we should think about a more generic way to enforce types at 
+  //runtime?
+  const isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
 
+  //TODO: I would recommend against using console.warn as an error handling mechanism
+  //this cloggs up the users console and doesn't provide the user an ability to handle
+  //this error
   /** is findr being used in regex mode */
   const _isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
   if (!_isRegex && target instanceof RegExp)
@@ -48,11 +55,15 @@ export function findr({
         return new RegExp(source, flags);
       };
 
+  //TODO: I'm seeing a code-smell here. Performing if-then statements to variable assignment
+  //is running an evaluator to early. 
+  //TODO: needs increased support for multiple languages
   /** regex pattern for a wordlike character */
-  const WordLike = isXre ? `p{Letter}\\p{Number}` : `\\w\\d`; // needs increased support for multiple languages
+  const wordLike = isXre ? `p{Letter}\\p{Number}` : `\\w\\d`;
 
   /** regex pattern for uppercase character */
-  const UppercaseLetter = isXre ? `\\p{Uppercase_Letter}` : `[A-Z]`; // needs increased support for multiple languages
+  const uppercaseLetter = isXre ? `\\p{Uppercase_Letter}` : `[A-Z]`;
+
 
   /** adds patterns needed to fit findr's config to a given RegExp */
   function prepareRegExp({
@@ -64,12 +75,12 @@ export function findr({
   }) {
     const { source, flags } = regexp;
     return isWordMatched
-      ? regexer(`(^|[^${WordLike}])(${source})(?=[^${WordLike}]|$)`, flags)
+      ? regexer(`(^|[^${wordLike}])(${source})(?=[^${wordLike}]|$)`, flags)
       : regexer(`()(${source})`, flags);
   }
 
   /** regex gotten from findr's target input */
-  const rgxData = _isRegex
+  const rgxData = isRegex
     ? evalRegex(target)
     : { source: escapeRegExp(target), flags: null };
 
@@ -141,7 +152,7 @@ export function findr({
             if (isUpperCase(match)) {
               return replaced.toUpperCase();
             }
-            if (new RegExp(regexer(UppercaseLetter)).test(match[0])) {
+            if (new RegExp(regexer(uppercaseLetter)).test(match[0])) {
               return replaced[0].toUpperCase() + replaced.slice(1);
             }
             return replaced;

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -1,5 +1,7 @@
-import { FindrParams, FindrResult, resultKey } from './index.d';
+import { SearchAndReplace, SearchResult, ResultKey } from './index.d';
 import { escapeRegExp, evalRegex, isUpperCase } from './utils';
+
+type RegexFlags = Array<string>;
 
 /** 
 *  findr extends javascript's String.replace() by handling options like Preserve Case, 
@@ -23,12 +25,13 @@ export function findr({
     isWordMatched = false,
     isCasePreserved = false,
   } = {},
-}: FindrParams) {
+}: SearchAndReplace) {
   // START BUILDING SEARCH REGEXP
 
   /** default flags to be used for regex pattern */
-  const defaultFlags = ['g'];
-  if (!isCaseMatched) defaultFlags.push('i');
+  const defaultFlags : RegexFlags =  !isCaseMatched ? ['g', 'i'] : ['g'];
+
+  const _isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
 
   /** is findr being used in regex mode */
   const _isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
@@ -88,7 +91,7 @@ export function findr({
 
   let searchIndex = 0;
   let replaceIndex = 0;
-  const results: FindrResult[] = [];
+  const results: SearchResult[] = [];
   const replaced =
     target !== ''
       ? source.replace(initialRgx, function (...args) {
@@ -148,7 +151,7 @@ export function findr({
           const replaced = evaluateCase(match, match.replace(finalRgx, r));
 
           /** key for specific match index that needs to be replaced */
-          const replacePointer: resultKey = buildResultKey
+          const replacePointer: ResultKey = buildResultKey
             ? buildResultKey(replaceIndex)
             : replaceIndex;
           replaceIndex++;

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -12,7 +12,7 @@ export default function findr({
   target,
   replacement = '',
   replacementKeys = [],
-  metadata,
+  metadata: mdata,
   config: {
     filterCtxMatch = (match: string) => match,
     filterCtxReplacement = (replacement: string) => replacement,
@@ -60,7 +60,6 @@ export default function findr({
     , replacement
     , buildResultKey
     , replacementKeys
-    , metadata
     , searchIndex
     , ctxLen
     , filterCtxMatch
@@ -70,7 +69,12 @@ export default function findr({
   //TODO: rework the types involved so that this empty string check isn't required
   const replaced = target !== '' ? source.replace(wholeWordRegex, replaceFunc_) : source;
 
-  return { results, replaced };
+  const adjoinMetadata = ({metadata, ...result} : SearchResult) => 
+    ({ metadata : {...metadata, ...mdata}
+    , ...result
+    })
+
+  return { results: results.map(adjoinMetadata), replaced };
 }
 
 function replaceFunc
@@ -81,7 +85,6 @@ function replaceFunc
   //TODO: eliminate from function argument
   , buildResultKey : any
   , replacementKeys : any
-  , metadata : any
   //TODO: eliminate from function argument
   , searchIndex : any
   , ctxLen : any
@@ -110,8 +113,8 @@ function replaceFunc
   //TODO: why is the `match` the 3rd subgroup?
   const replacedText = 
     typeof replacement === 'function' 
-        ? replacement({ index: searchIndex, match, groups: oldArgs, position: pos, source, namedGroups })
-        : replacement
+    ? replacement({ index: searchIndex, match, groups: oldArgs, position: pos, source, namedGroups })
+    : replacement
 
   /** replacement string modified to match findr's replacement config */
   const replacedCaseHandled = 
@@ -151,7 +154,6 @@ function replaceFunc
           position: pos,
           groups: oldArgs,
           namedGroups,
-          ...metadata,
       }}
     )
 }}   

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -140,20 +140,6 @@ export default function findr({
     const pos = tmpPos + auxMatch.length;
     const match: string = args.shift();
 
-    //TODO: any function with the type `() -> a` is isomorphic to `a`. The only difference
-    //is that `() -> a` is a thunk and `a` is not. do we need to do lazy evaluation here?
-    // START BUILDING REPLACEMENT STRING
-
-    /** gets the replacement string from findr's replacement input */
-    const replacementCB = replacementCB_(replacement, replaceIndex, match, args, pos, source, namedGroups);
-
-    //TODO: code-smell. Variable name is a single letter. Typically this indicates a name-binding that has 
-    //little denotational semantics. If this is the case can we remove the variable, otherwise rename it 
-    //to something more meaningful.
-    /** replacement string from findr's replacement input */
-    /** modifies replacement string according to findr's replacement config */
-    const r = replacementCB();
-
     //TODO: code-smell: this function has a single callsite. Typically this means we can rework the logic to
     //not need the function or replace the function 
     //TODO: co
@@ -171,7 +157,9 @@ export default function findr({
 
     //TODO: name binding masks already defined name binding (defined on line 94)
     /** replacement string modified to match findr's replacement config */
-    const replaced = evaluateCase(match, match.replace(finalRgx, r));
+    const replaced = evaluateCase(match, 
+      match.replace(finalRgx, replacementCallback(replacement, replaceIndex, match, args, pos, source, namedGroups))
+    );
 
     //TODO: I don't this interface to buildResultKey is a good idea...just a gut feeling here.
     /** key for specific match index that needs to be replaced */
@@ -237,7 +225,7 @@ export default function findr({
   return { results, replaced };
 }
  
-function replacementCB_(replacement: string | ReplacementCallback, replaceIndex: number, match: string, args: any[], pos: any, source: any, namedGroups: any) {
+function replacementCallback(replacement: string | ReplacementCallback, replaceIndex: number, match: string, args: any[], pos: any, source: any, namedGroups: any) {
     return function(): string {
         //TODO: the type of `replacement` (according to index.d.ts) is a string. Here I recommend any of:
         //  - update the type to properly reflect the potential inputs

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -1,6 +1,6 @@
 import * as C from './CaseHandler';
 import { SearchAndReplace, SearchResult } from './index.d';
-import { onlyReplace, replaceAndResult } from './ResultsBuilder';
+import * as R from './ResultsBuilder';
 import * as S from './SourceAndFlags'
 
 /** 
@@ -124,13 +124,12 @@ function replaceFunc
     , namedGroups 
     })
 
-  const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(searchIndex)) 
-
   // REPLACE IF replacePointer IS INCLUDED IN replacementKeys given by user
   //TODO: why are we concatenating the first subgroup with the replaced text? 
-  return hasReplacementKey
-  ? onlyReplace(preWordSpaceCharacter + replacedCaseHandled)
-  : replaceAndResult(entireStringMatch,
+  return R.ifElse(
+   R.map(R.searchIndex, i => replacementKeys === 'all' || replacementKeys.includes(buildResultKey(i)))
+  , R.pure(preWordSpaceCharacter + replacedCaseHandled)
+  , R.replaceAndResult(entireStringMatch,
       {match: filterCtxMatch ? filterCtxMatch(subStringMatch) : subStringMatch,
       replacement: filterCtxReplacement ? filterCtxReplacement(replacedCaseHandled) : replacedCaseHandled,
       context: 
@@ -149,4 +148,5 @@ function replaceFunc
           namedGroups,
       }}
     )
+  )
 }}   

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -91,24 +91,6 @@ export function findr({
   /** regex pattern for uppercase character */
   const uppercaseLetter = isXre ? `\\p{Uppercase_Letter}` : `[A-Z]`;
 
-  //TODO: code-smell.. you're defining a function but it's only being called once elsewhere 
-  //TODO: could we move this out of the scope of findr?
-  //TODO: add return type annotation
-  /** adds patterns needed to fit findr's config to a given RegExp */
-  function prepareRegExp({
-    regexp,
-    isWordMatched,
-  }: {
-    regexp: RegExp;
-    isWordMatched: boolean;
-  }) {
-    const { source, flags } = regexp;
-    //TODO: you have here an EDSL for constructing regexes...why not make this its own module?
-    return isWordMatched
-      ? regexer(`(^|[^${wordLike}])(${source})(?=[^${wordLike}]|$)`, flags)
-      : regexer(`()(${source})`, flags);
-  }
-
   /** regex gotten from findr's target input */
   const rgxData = isRegex
     ? evalRegex(target)
@@ -124,10 +106,13 @@ export function findr({
   const finalRgx = regexer(rgxData.source, flags.join(''));
 
   /** regex with findr's search config */
-  const initialRgx = prepareRegExp({
-    regexp: finalRgx,
-    isWordMatched,
-  });
+  const { source: source_, flags: flags_ } = finalRgx;
+
+  //TODO: you have here an EDSL for constructing regexes...why not make this its own module?
+  /** adds patterns needed to fit findr's config to a given RegExp */
+  const initialRgx = isWordMatched
+      ? regexer(`(^|[^${wordLike}])(${source_})(?=[^${wordLike}]|$)`, flags_)
+      : regexer(`()(${source_})`, flags_);
 
   //START FINDING AND REPLACING
 

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -29,11 +29,15 @@ export default function findr({
   // START BUILDING SEARCH REGEXP
 
   /** default flags to be used for regex pattern */
+  // CHRIS: Yay this is more readable. What does the global flag do?
   const defaultFlags : S.RegexFlags =  !isCaseMatched ? S.mergeFlags(S.global, S.caseInsensitive) : S.global;
   
+  // CHRIS: What does wordLike mean?
   const {regexBuilder, wordLike } = 
     xre instanceof Function ? S.regexBuilderAndConfigFromFunction(xre) : S.defaultRegexAndConfig 
 
+  // CHRIS: The name 'mkFinalRegex' does point to the fact that it is a function,
+  // but the SourceAndFlags type doesn't sound like a function
   const mkFinalRegex = (s : RegExp | string) : S.SourceAndFlags => 
     s instanceof RegExp ? S.fromRegex(s) : S.regexStringToRegexer(s) 
 
@@ -47,12 +51,14 @@ export default function findr({
   const onlySourceRegex = regexBuilder(`()(${source_})`, flags_)
 
   /** adds patterns needed to fit findr's config to a given RegExp */
+  // CHRIS: Is wholeWordRegex a good name if we aren't always matching the whole word?
   const wholeWordRegex = isWordMatched ? regexWithWholeWord : onlySourceRegex
 
   //START FINDING AND REPLACING
   let searchIndex = 0;
   let results : SearchResult[] = []
 
+  // CHRIS: The andThen function was confusing to wrap my brain around
   const createReplacement = 
     C.andThen
     ( typeof replacement === 'function' ? (replacement as C.CaseHandler<string>) 
@@ -61,6 +67,8 @@ export default function findr({
     )
 
   //TODO: it might be worth using a Reader functor here...
+  // CHRIS: Single-character variables are scary.
+  // Combining that and currying can make this function look alien
   const replaceFunc_ = (a : any, b : any, c : any, ...d : any[]) => replaceFunc
     ( source
     , createReplacement
@@ -76,6 +84,7 @@ export default function findr({
   const replaced = target !== '' ? source.replace(wholeWordRegex, replaceFunc_) : source;
 
   //TODO: break the external API so this is no longer needed
+  // CHRIS: Yeah this is a little weird
   const adjoinMetadata = ({metadata, ...result} : SearchResult) => 
     ({ metadata : {...metadata, source, match: result.match, ...mdata}
     , ...result
@@ -108,6 +117,7 @@ function replaceFunc
   const namedGroups = hasGroups ? args.at(-1) : undefined;
 
   //TODO: rename this to something more understandable
+  // CHRIS: Agree ^
   const pos = args.at(hasGroups ? -3 : -2) + preWordSpaceCharacter.length;
   
   //TODO: remove the need for oldArgs (this will break the legacy API)
@@ -126,6 +136,7 @@ function replaceFunc
 
   // REPLACE IF replacePointer IS INCLUDED IN replacementKeys given by user
   //TODO: why are we concatenating the first subgroup with the replaced text? 
+  // CHRIS: I think this exploded my brain.
   return R.ifElse(
    R.map(R.searchIndex, i => replacementKeys === 'all' || replacementKeys.includes(buildResultKey(i)))
   , R.pure(preWordSpaceCharacter + replacedCaseHandled)

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -30,7 +30,7 @@ export default function findr({
   /** default flags to be used for regex pattern */
   const defaultFlags : S.RegexFlags =  !isCaseMatched ? S.mergeFlags(S.global, S.caseInsensitive) : S.global;
   
-  const {regexBuilder, wordLike, uppercaseLetter} = 
+  const {regexBuilder, wordLike } = 
     xre instanceof Function ? S.regexBuilderAndConfigFromFunction(xre) : S.defaultRegexAndConfig 
 
   const mkFinalRegex = (s : RegExp | string) : S.SourceAndFlags => 
@@ -55,7 +55,6 @@ export default function findr({
   //TODO: it might be worth using a Reader functor here...
   const replaceFunc_ = (a : any, b : any, c : any, ...d : any[]) => replaceFunc
     ( source
-    , uppercaseLetter
     , isCasePreserved
     , replacement
     , buildResultKey
@@ -77,9 +76,14 @@ export default function findr({
   return { results: results.map(adjoinMetadata), replaced };
 }
 
+const maintainCase = (match : string, replaced : string) =>
+  String(match).toUpperCase() === match ? String(replaced).toUpperCase() 
+  //TODO: remove need to pass in uppercase regex
+  : match[0].toUpperCase() ? `${replaced[0].toUpperCase()}${replaced.slice(1)}`
+  : replaced
+
 function replaceFunc
   ( source : string
-  , uppercaseLetter : any
   , isCasePreserved : any
   , replacement : any
   //TODO: eliminate from function argument
@@ -115,12 +119,6 @@ function replaceFunc
     typeof replacement === 'function' 
     ? replacement({ index: searchIndex, match: subStringMatch, groups: oldArgs, position: pos, source, namedGroups })
     : replacement
-
-  const maintainCase = (match : string, replaced : string) =>
-    String(match).toUpperCase() === match ? String(replaced).toUpperCase() 
-    //TODO: remove need to pass in uppercase regex
-    : uppercaseLetter.test(match[0]) ? replaced[0].toUpperCase() + replaced.slice(1)
-    : replaced
 
   /** replacement string modified to match findr's replacement config */
   const replacedCaseHandled =  !isCasePreserved ? replacedText : maintainCase(subStringMatch, replacedText)

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -233,21 +233,15 @@ function replaceFunc
   , filterCtxMatch : any
   , filterCtxReplacement : any
   ) { return (...args: any[]) => {
+
   //TODO: invert the logic here. According to the MDN documentation these variables can be inferred
   //from the initialRgx value. That is, the instance of `...args` can be inferred directly from
   //the initialRgx construction. I recommend reworking the type of initalRgx to make this implication
   //easier. 
+
   // START BUILDING MATCH DATA
   /** if the last argument of string.replace callback is an object it means the regexp contains groups */
-  const containsGroup = typeof args[args.length - 1] === 'object';
-  /** get the groups if they exist and remove them from args */
-  const namedGroups = containsGroup ? args.pop() : undefined;
-  const source = args.pop();
-  const tmpPos = args.pop();
-  const tmpMatch = args.shift();
-  const auxMatch = args.shift();
-  const pos = tmpPos + auxMatch.length;
-  const match: string = args.shift();
+  const { match, pos, source, namedGroups, auxMatch, tmpMatch } = handleRegexGroups(args);
 
   //TODO: name binding masks already defined name binding (defined on line 94)
   /** replacement string modified to match findr's replacement config */
@@ -262,7 +256,6 @@ function replaceFunc
       : replaceIndex;
 
   replaceIndex++;
-
 
   // REPLACE IF replacePointer IS INCLUDED IN replacementKeys given by user
   if (replacementKeys === 'all' ||
@@ -282,7 +275,17 @@ function replaceFunc
   //  - result (this is only being used as the argument to `results.push`)
   // START BUILDING THE RESULT IF MATCH IS NOT REPLACED
   /** substring before matched result */
-  const { ctxMatch, ctxReplacement, ctxBefore, ctxAfter, extCtxBefore, extCtxAfter, searchPointer } = preMatchSubstring(source, pos, ctxLen, match, filterCtxMatch, filterCtxReplacement, replaced, buildResultKey, searchIndex);
+  const { ctxMatch, ctxReplacement, ctxBefore, ctxAfter, extCtxBefore, extCtxAfter, searchPointer } = preMatchSubstring
+    ( source
+    , pos
+    , ctxLen
+    , match
+    , filterCtxMatch
+    , filterCtxReplacement
+    , replaced
+    , buildResultKey
+    , searchIndex
+    )
 
   //TODO: add result metadata as filterCtxReplacement arg
   const result = {
@@ -310,3 +313,19 @@ function replaceFunc
 
   return tmpMatch;
 }}
+
+function handleRegexGroups(args: any[]) : { match: string; pos: any; source: any; namedGroups: any; auxMatch: any; tmpMatch: any; } {
+  const containsGroup = typeof args[args.length - 1] === 'object';
+
+  /** get the groups if they exist and remove them from args */
+  const namedGroups = containsGroup ? args.pop() : undefined;
+  const source = args.pop();
+  const tmpPos = args.pop();
+  const tmpMatch = args.shift();
+  const auxMatch = args.shift();
+  const pos = tmpPos + auxMatch.length;
+  const match = args.shift();
+
+  return { match, pos, source, namedGroups, auxMatch, tmpMatch };
+}
+

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -82,10 +82,12 @@ function replaceFunc
   , isCasePreserved : any
   , finalRgx : any
   , replacement : any
+  //TODO: eliminate from function argument
   , replaceIndex : any
   , buildResultKey : any
   , replacementKeys : any
   , metadata : any
+  //TODO: eliminate from function argument
   , searchIndex : any
   , ctxLen : any
   , filterCtxMatch : any
@@ -123,11 +125,14 @@ function replaceFunc
   const replacedCaseHandled = 
     !isCasePreserved ? replacedText
     : String(match).toUpperCase() === match ? String(replacedText).toUpperCase() 
+    //TODO: remove need to pass in regexer
     : regexer(uppercaseLetter).test(match[0]) ? replacedText[0].toUpperCase() + replacedText.slice(1)
     : replacedText
 
   const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(replaceIndex) as string) 
 
+  //TODO: I don't this interface to buildResultKey is a good idea...just a gut feeling here.
+  //TODO: unify the return results
   // REPLACE IF replacePointer IS INCLUDED IN replacementKeys given by user
   return hasReplacementKey
   ? /** if a replacementKey matches current result this result won't be included in the list of results */
@@ -146,9 +151,9 @@ function replaceFunc
         },
       resultKey: buildResultKey(searchIndex),
       metadata: {
-          //TODO: remove this since it's unecessary
+          //TODO: remove this since it's unecessary and bloating the return value
           source: source,
-          //TODO: remove this since it's unecessary
+          //TODO: remove this since it's unecessary (and already included in the above code)
           match: match,
           searchIndex,
           position: pos,

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -8,6 +8,26 @@ type RegexFlags = Array<string>;
 *  Match Word, Regex, and allowing consumers to extend it further.
 *  It formats it's response in a way that is easier to consume by a Find and Replace UI.
 */
+
+/*
+TODO: Code Readability Suggestions
+
+It could be helpful to **separate Findr and Multiline into separate
+files and then import/export them in `index.ts`**.  It’s harder exploring
+through the codebase when I’m sorting through which `index.ts` file I’m looking at.
+- It also makes the imports within the files more readable (I get confused when
+  I see imports of index files and which folder they’re being imported from.
+  Like import x from “../../.”)
+
+A lot of the code was in one bigger function. **Creating smaller functions that
+group similar operations** (creating flags, preparing initial regex, etc.)
+**could help improve readability.**
+  1. For Example…
+      1. Wrapping the functionality in `source.replace` on **line 74** in a function
+      2. Wrapping the `defaultFlags` const with other code that generates flags
+      3. etc.
+*/
+
 export function findr({
   source,
   target,

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -1,6 +1,11 @@
 import { FindrParams, FindrResult, resultKey } from './index.d';
 import { escapeRegExp, evalRegex, isUpperCase } from './utils';
 
+/** 
+*  findr extends javascript's String.replace() by handling options like Preserve Case, 
+*  Match Word, Regex, and allowing consumers to extend it further.
+*  It formats it's response in a way that is easier to consume by a Find and Replace UI.
+*/
 export function findr({
   source,
   target,
@@ -19,25 +24,34 @@ export function findr({
     isCasePreserved = false,
   } = {},
 }: FindrParams) {
+  // START BUILDING SEARCH REGEXP
+
+  /** default flags to be used for regex pattern */
   const defaultFlags = ['g'];
-
   if (!isCaseMatched) defaultFlags.push('i');
-  const _isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
 
+  /** is findr being used in regex mode */
+  const _isRegex = typeof isRegex === 'boolean' ? isRegex : isRegex === 'true';
   if (!_isRegex && target instanceof RegExp)
     console.warn('isRegex is set to false but target of type RegExp given.');
 
+  /** is user providing an instance of XRegExp */
   const isXre = xre instanceof Function;
 
+  /** regex engine (default or xregexp) */
   const regexer = isXre
     ? xre
     : function (source: string, flags = '') {
         return new RegExp(source, flags);
       };
 
-  const WordLike = isXre ? `p{Letter}\\p{Number}` : `\\w\\d`;
-  const UppercaseLetter = isXre ? `\\p{Uppercase_Letter}` : `[A-Z]`;
+  /** regex pattern for a wordlike character */
+  const WordLike = isXre ? `p{Letter}\\p{Number}` : `\\w\\d`; // needs increased support for multiple languages
 
+  /** regex pattern for uppercase character */
+  const UppercaseLetter = isXre ? `\\p{Uppercase_Letter}` : `[A-Z]`; // needs increased support for multiple languages
+
+  /** adds patterns needed to fit findr's config to a given RegExp */
   function prepareRegExp({
     regexp,
     isWordMatched,
@@ -51,20 +65,26 @@ export function findr({
       : regexer(`()(${source})`, flags);
   }
 
+  /** regex gotten from findr's target input */
   const rgxData = _isRegex
     ? evalRegex(target)
     : { source: escapeRegExp(target), flags: null };
 
+  /** merged default flags with inputted flags */
   const flags = rgxData.flags
     ? [...new Set([...rgxData.flags, ...defaultFlags])]
     : defaultFlags;
 
+  /** clean regex without findr's search configs */
   const finalRgx = regexer(rgxData.source, flags.join(''));
 
+  /** regex with findr's search config */
   const initialRgx = prepareRegExp({
     regexp: finalRgx,
     isWordMatched,
   });
+
+  //START FINDING AND REPLACING
 
   let searchIndex = 0;
   let replaceIndex = 0;
@@ -72,7 +92,11 @@ export function findr({
   const replaced =
     target !== ''
       ? source.replace(initialRgx, function (...args) {
+          // START BUILDING MATCH DATA
+
+          /** if the last argument of string.replace callback is an object it means the regexp contains groups */
           const containsGroup = typeof args[args.length - 1] === 'object';
+          /** get the groups if they exist and remove them from args */
           const namedGroups = containsGroup ? args.pop() : undefined;
           const source = args.pop();
           const tmpPos = args.pop();
@@ -81,6 +105,9 @@ export function findr({
           const pos = tmpPos + auxMatch.length;
           const match: string = args.shift();
 
+          // START BUILDING REPLACEMENT STRING
+
+          /** gets the replacement string from findr's replacement input */
           const replacementCB = function (): string {
             if (typeof replacement === 'function') {
               const rep = replacement({
@@ -101,8 +128,10 @@ export function findr({
             );
           };
 
+          /** replacement string from findr's replacement input */
           const r = replacementCB();
 
+          /** modifies replacement string according to findr's replacement config */
           const evaluateCase = (match: string, replaced: string) => {
             //TODO: Add callback to allow users to make their own case evaluation;
             if (!isCasePreserved) return replaced;
@@ -115,26 +144,38 @@ export function findr({
             return replaced;
           };
 
+          /** replacement string modified to match findr's replacement config */
           const replaced = evaluateCase(match, match.replace(finalRgx, r));
 
+          /** key for specific match index that needs to be replaced */
           const replacePointer: resultKey = buildResultKey
             ? buildResultKey(replaceIndex)
             : replaceIndex;
           replaceIndex++;
+
+          // REPLACE IF replacePointer IS INCLUDED IN replacementKeys given by user
+
           if (
             replacementKeys === 'all' ||
             replacementKeys.includes(replacePointer as string)
           ) {
+            /** if a replacementKey matches current result this result won't be included in the list of results */
             return auxMatch + replaced;
           }
 
+          // START BUILDING THE RESULT IF MATCH IS NOT REPLACED
+
+          /** substring before matched result */
           const ctxBefore = source.slice(pos - ctxLen, pos);
+          /** substring after matched result */
           const ctxAfter = source.slice(
             pos + match.length,
             pos + match.length + ctxLen
           );
 
+          /** all source text before matched result */
           const extCtxBefore = source.slice(0, pos);
+          /** all source text after matched result */
           const extCtxAfter = source.slice(pos + match.length, -1);
 
           const ctxMatch = filterCtxMatch ? filterCtxMatch(match) : match;
@@ -142,6 +183,7 @@ export function findr({
             ? filterCtxReplacement(replaced)
             : replaced;
 
+          /** creates a pointer to this result */
           const searchPointer = buildResultKey
             ? buildResultKey(searchIndex)
             : searchIndex;

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -1,4 +1,4 @@
-import { SearchAndReplace, SearchResult, ResultKey, Filter, ReplacementCallback } from './index.d';
+import { SearchAndReplace, SearchResult, ResultKey, ReplacementCallback } from './index.d';
 import * as S from './SourceAndFlags'
 
 /** 
@@ -39,7 +39,6 @@ export default function findr({
     ctxLen = 0,
     //TODO: rename xre - it's difficult to follow
     xregexp: xre,
-    isRegex = false,
     isCaseMatched = true,
     isWordMatched = false,
     isCasePreserved = false,
@@ -126,7 +125,7 @@ function replacementCallbackFunc
   
 function replacementString(s : string) : (() => string) {return () => s}
 
-function preMatchSubstring(source: any, pos: any, ctxLen: number, match: string, filterCtxReplacement: Filter, replaced: string) {
+function preMatchSubstring(source: any, pos: any, ctxLen: number, match: string ) {
     const ctxBefore = source.slice(pos - ctxLen, pos);
 
     /** substring after matched result */
@@ -141,11 +140,7 @@ function preMatchSubstring(source: any, pos: any, ctxLen: number, match: string,
     /** all source text after matched result */
     const extCtxAfter = source.slice(pos + match.length, -1);
 
-    const ctxReplacement = filterCtxReplacement
-        ? filterCtxReplacement(replaced)
-        : replaced;
-
-    return { ctxReplacement, ctxBefore, ctxAfter, extCtxBefore, extCtxAfter  };
+    return { ctxBefore, ctxAfter, extCtxBefore, extCtxAfter  };
 }
 
 
@@ -228,13 +223,11 @@ function replaceFunc
   //  - result (this is only being used as the argument to `results.push`)
   // START BUILDING THE RESULT IF MATCH IS NOT REPLACED
   /** substring before matched result */
-  const { ctxReplacement, ctxBefore, ctxAfter, extCtxBefore, extCtxAfter } = preMatchSubstring
+  const { ctxBefore, ctxAfter, extCtxBefore, extCtxAfter } = preMatchSubstring
     ( source
     , pos
     , ctxLen
     , match
-    , filterCtxReplacement
-    , replaced
     )
 
   //TODO: I don't this interface to buildResultKey is a good idea...just a gut feeling here.
@@ -255,7 +248,7 @@ function replaceFunc
   //TODO: add result metadata as filterCtxReplacement arg
   const result = {
       match: filterCtxMatch ? filterCtxMatch(match) : match,
-      replacement: ctxReplacement,
+      replacement: filterCtxReplacement ? filterCtxReplacement(replaced) : replaced,
       context: { before: ctxBefore, after: ctxAfter },
       extContext: { before: extCtxBefore, after: extCtxAfter },
       resultKey: buildResultKey(searchIndex),

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -54,7 +54,6 @@ export default function findr({
   //TODO: it might be worth using a Reader functor here...
   const replaceFunc_ = (a : any, b : any, c : any, ...d : any[]) => replaceFunc
     ( source
-    , regexBuilder
     , uppercaseLetter
     , isCasePreserved
     , targetRegex
@@ -77,7 +76,6 @@ export default function findr({
 
 function replaceFunc
   ( source : string
-  , regexer : any
   , uppercaseLetter : any
   , isCasePreserved : any
   , finalRgx : any
@@ -106,6 +104,7 @@ function replaceFunc
 
   //TODO: rename this to something more understandable
   const pos = args.at(hasGroups ? -3 : -2) + auxMatch.length;
+
   
   //TODO: remove the need for oldArgs (this will break the legacy API)
   //in order to maintain the legacy behavior of args we need to modify the args array
@@ -126,7 +125,7 @@ function replaceFunc
     !isCasePreserved ? replacedText
     : String(match).toUpperCase() === match ? String(replacedText).toUpperCase() 
     //TODO: remove need to pass in regexer
-    : regexer(uppercaseLetter).test(match[0]) ? replacedText[0].toUpperCase() + replacedText.slice(1)
+    : uppercaseLetter.test(match[0]) ? replacedText[0].toUpperCase() + replacedText.slice(1)
     : replacedText
 
   const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(replaceIndex) as string) 

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -28,27 +28,9 @@ export default function findr({
 
   /** default flags to be used for regex pattern */
   const defaultFlags : S.RegexFlags =  !isCaseMatched ? S.mergeFlags(S.global, S.caseInsensitive) : S.global;
-
-  //TODO: needs increased support for multiple languages
-  /** regex engine (default or xregexp) */
-  /** is user providing an instance of XRegExp */
-  const {regexBuilder, wordLike, uppercaseLetter} = xre instanceof Function
-    ? { regexBuilder: xre 
-      /** regex pattern for a wordlike character */
-      , wordLike: `p{Letter}\\p{Number}` 
-
-      /** regex pattern for uppercase character */
-      , uppercaseLetter: `\\p{Uppercase_Letter}` 
-      }
-
-    : { regexBuilder: (source: string, flags = '') => new RegExp(source, flags)
-      /** regex pattern for a wordlike character */
-      , wordLike : `\\w\\d`
-
-      /** regex pattern for uppercase character */
-      , uppercaseLetter: `[A-Z]`
-      }
-
+  
+  const {regexBuilder, wordLike, uppercaseLetter} = 
+    xre instanceof Function ? S.regexBuilderAndConfigFromFunction(xre) : S.defaultRegexAndConfig 
 
   const mkFinalRegex = (s : RegExp | string) : S.SourceAndFlags => s instanceof RegExp ? S.fromRegex(s) : S.regexStringToRegexer(s) 
 

--- a/packages/fnr-text/src/lib/index.ts
+++ b/packages/fnr-text/src/lib/index.ts
@@ -50,7 +50,6 @@ export default function findr({
 
   //START FINDING AND REPLACING
   let searchIndex = 0;
-  let replaceIndex = 0;
   let results : SearchResult[] = []
 
   //TODO: it might be worth using a Reader functor here...
@@ -59,7 +58,6 @@ export default function findr({
     , uppercaseLetter
     , isCasePreserved
     , replacement
-    , replaceIndex
     , buildResultKey
     , replacementKeys
     , metadata
@@ -67,7 +65,7 @@ export default function findr({
     , ctxLen
     , filterCtxMatch
     , filterCtxReplacement
-    )(a,b, c, ...d)(results, searchIndex, replaceIndex)
+    )(a,b, c, ...d)(results, searchIndex)
 
   //TODO: rework the types involved so that this empty string check isn't required
   const replaced = target !== '' ? source.replace(wholeWordRegex, replaceFunc_) : source;
@@ -81,7 +79,6 @@ function replaceFunc
   , isCasePreserved : any
   , replacement : any
   //TODO: eliminate from function argument
-  , replaceIndex : any
   , buildResultKey : any
   , replacementKeys : any
   , metadata : any
@@ -113,16 +110,8 @@ function replaceFunc
   //TODO: why is the `match` the 3rd subgroup?
   const replacedText = 
     typeof replacement === 'function' 
-        ? replacement({ index: replaceIndex, match, groups: oldArgs, position: pos, source, namedGroups })
+        ? replacement({ index: searchIndex, match, groups: oldArgs, position: pos, source, namedGroups })
         : replacement
-
-    //match.replace
-    //(targetRegex, 
-    //  //TODO: invert the dependencies here
-    //  typeof replacement === 'function' 
-    //    ? () => replacement({ index: replaceIndex, match, groups: oldArgs, position: pos, source, namedGroups })
-    //    : () => replacement
-    //)
 
   /** replacement string modified to match findr's replacement config */
   const replacedCaseHandled = 
@@ -132,7 +121,7 @@ function replaceFunc
     : uppercaseLetter.test(match[0]) ? replacedText[0].toUpperCase() + replacedText.slice(1)
     : replacedText
 
-  const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(replaceIndex) as string) 
+  const hasReplacementKey = replacementKeys === 'all' || replacementKeys.includes(buildResultKey(searchIndex) as string) 
 
   //TODO: I don't this interface to buildResultKey is a good idea...just a gut feeling here.
   //TODO: unify the return results

--- a/packages/fnr-text/src/lib/multiline/index.d.ts
+++ b/packages/fnr-text/src/lib/multiline/index.d.ts
@@ -1,14 +1,14 @@
-import { FindrConfig, resultKey, FindrParams, FindrReturn } from '../index.d'
+import { FindrConfig, ResultKey, SearchAndReplace, ReplacedAndResults } from '../index.d'
 
-export declare const findrMultiLine: (params: FindrMultiLineParams) => FindrReturn;
+export declare const findrMultiLine: (params: FindrMultiLineParams) => ReplacedAndResults;
 
 export default findrMultiLine;
 
 export interface FindrMultiLineConfig
   extends Omit<FindrConfig, 'buildResultKey'> {
-  buildResultKey?: (index: number, lineNumber: number) => resultKey;
+  buildResultKey?: (index: number, lineNumber: number) => ResultKey;
 }
 
-export interface FindrMultiLineParams extends Omit<FindrParams, 'config'> {
+export interface FindrMultiLineParams extends Omit<SearchAndReplace, 'config'> {
   config?: FindrMultiLineConfig;
 }

--- a/packages/fnr-text/src/lib/multiline/index.ts
+++ b/packages/fnr-text/src/lib/multiline/index.ts
@@ -1,12 +1,12 @@
 import fnr from '..';
-import { FindrResult } from '../index.d';
+import { SearchResult } from '../index.d';
 import { FindrMultiLineParams } from './index.d';
 
 export function findrMultiLine(params: FindrMultiLineParams) {
   const { source, metadata, config = {}, target } = params;
   const { buildResultKey } = config;
   const _source = source.split('\n');
-  let _results: FindrResult[] = [];
+  let _results: SearchResult[] = [];
   const _replaced: string[] = [];
   _source.forEach((line: string, lineIndex: number) => {
     const lineNumber = lineIndex + 1;

--- a/packages/fnr-text/src/lib/utils.ts
+++ b/packages/fnr-text/src/lib/utils.ts
@@ -1,10 +1,15 @@
+//TODO: this file seems uncessary for the following reasons:
+//  - it uses types (e.g RegExp) that were never imported
+//  - all of these functions have a single callsite
 export function escapeRegExp(string: string | RegExp) {
   const _string = string instanceof RegExp ? string.source : string;
   return _string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+//TODO: the eval of a RegExp is to return the original source? Maybe we should rename this function?
 export function evalRegex(source: string | RegExp) {
   if (source instanceof RegExp) return source;
+  //TODO: runtime type checking. Typescript should already prevent the need for these checks.
   if (typeof source !== "string")
     throw new Error("Arg `source` shoud be of type string or RegExp");
   const results = source.match(/\/(.+)\/(?=(\w*$))/);
@@ -12,6 +17,7 @@ export function evalRegex(source: string | RegExp) {
   return { source: results[1], flags: results[2] };
 }
 
+//TODO: is this necessary? Will it handle languages defined in a non-ASCII language?
 export function isUpperCase(input: string) {
   return input.toUpperCase() === input && input.toLowerCase() !== input;
 }

--- a/packages/fnr-text/src/lib/utils.ts
+++ b/packages/fnr-text/src/lib/utils.ts
@@ -1,22 +1,3 @@
-//TODO: this file seems uncessary for the following reasons:
-//  - it uses types (e.g RegExp) that were never imported
-//  - all of these functions have a single callsite
-export function escapeRegExp(string: string | RegExp) {
-  const _string = string instanceof RegExp ? string.source : string;
-  return _string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-//TODO: the eval of a RegExp is to return the original source? Maybe we should rename this function?
-export function evalRegex(source: string | RegExp) {
-  if (source instanceof RegExp) return source;
-  //TODO: runtime type checking. Typescript should already prevent the need for these checks.
-  if (typeof source !== "string")
-    throw new Error("Arg `source` shoud be of type string or RegExp");
-  const results = source.match(/\/(.+)\/(?=(\w*$))/);
-  if (!results?.[1]) return { source };
-  return { source: results[1], flags: results[2] };
-}
-
 //TODO: is this necessary? Will it handle languages defined in a non-ASCII language?
 export function isUpperCase(input: string) {
   return input.toUpperCase() === input && input.toLowerCase() !== input;

--- a/packages/fnr-text/src/lib/utils.ts
+++ b/packages/fnr-text/src/lib/utils.ts
@@ -1,4 +1,0 @@
-//TODO: is this necessary? Will it handle languages defined in a non-ASCII language?
-export function isUpperCase(input: string) {
-  return input.toUpperCase() === input && input.toLowerCase() !== input;
-}


### PR DESCRIPTION
Upon reviewing the code for `fnr-text` I've noted many improvements that could be made. 

TL;DR: the `fnr-text` needs to be refactored into 2 layers: A core module that is well-typed and is safe to make all the assumptions that are necessary. A second module that is the user interface for the library that provides a user-friendly interface.

A few first highlevel observations are the following:
  - an architecture diagram for `findr` needs to be constructed (if one already exists then it needs to be included in the typedoc)
  - The types defined need to be revisited. There are many refinements that need to be made (name changes, type refinement, and EDSL construction) to make this library production ready.
  - Fully lean into the typing system that TS provides. Assume users of your library are going to use TS and if they chose not to then they are need to know they are knowingly going into "the danger zone".  This leads to the next suggestion.
  - Implement the idea of "parse don't validate" to avoid needing excessive `if` statements and type-guarding. 

